### PR TITLE
Minor modification to support Bash 4

### DIFF
--- a/icssh
+++ b/icssh
@@ -67,7 +67,7 @@ do
   BOXES="${BOXES}\"${IP}\" "
 done
 
-BOXES=$(sed 's| |,|g' <<< $BOXES)
+BOXES=$(echo $BOXES | sed 's| |,|g')
 BOXES="{${BOXES}}"
 
 CMD="


### PR DESCRIPTION
It seems that `$(sed 's| |,|g' <<< $BOXES)` trims the `$BOXES` variable before `sed` acts upon it, but this is not the case in Bash 4, so the script breaks, as osascript complains due to the extra comma in the list of boxes. This fixes the problem for all versions of Bash.